### PR TITLE
Make contact tests fail if code under test doesn't make the right API calls

### DIFF
--- a/hubspot/contacts/__init__.py
+++ b/hubspot/contacts/__init__.py
@@ -105,7 +105,7 @@ def update_contact(contact, connection):
             property_type_by_property_name,
     )
     path = _CONTACT_UPDATING_URL_TEMPLATE.format(contact_id=contact.vid)
-    response = connection.send_post_request(
+    connection.send_post_request(
             path,
             properties_data,
     )

--- a/hubspot/contacts/__init__.py
+++ b/hubspot/contacts/__init__.py
@@ -82,6 +82,7 @@ def save_contacts(contacts, connection):
             contacts_batch_data,
             )
 
+
 def save_contact(contact, connection):
     property_type_by_property_name = \
         get_property_type_by_property_name(connection)
@@ -94,6 +95,7 @@ def save_contact(contact, connection):
             contact_data,
             )
     return response["vid"]
+
 
 def update_contact(contact, connection):
     property_type_by_property_name = \

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -32,13 +32,12 @@ class TestSaveContact(object):
 
     def test_invalid_property_raises_hubspot_client_error(self):
         contact = make_contact(None, properties={'is_polite': 'notavalidinput'})
-        with self._make_connection_for_contact_with_exception(
-                contact,
-                HubspotClientError("Property notavalidinput is invalid", "request-id")) as connection:
-            with assert_raises(HubspotClientError) as context:
-                with connection:
-                    save_contact(contact, connection)
-            eq_(context.exception.message, "Property notavalidinput is invalid")
+        with assert_raises(HubspotClientError) as context:
+            with self._make_connection_for_contact_with_exception(
+                    contact,
+                    HubspotClientError("Property notavalidinput is invalid", "request-id")) as connection:
+                save_contact(contact, connection)
+        eq_(context.exception.message, "Property notavalidinput is invalid")
 
     @staticmethod
     def _make_connection_for_contact_with_exception(contact, exception, available_property=None):

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -18,9 +18,8 @@ class TestSaveContact(object):
 
     def test_save_single_contact(self):
         contact = make_contact(None)
-        connection = self._make_connection_for_contact(1, contact)
-
-        vid = save_contact(contact, connection)
+        with self._make_connection_for_contact(1, contact) as connection:
+            vid = save_contact(contact, connection)
 
         eq_(1, vid)
 
@@ -33,12 +32,13 @@ class TestSaveContact(object):
 
     def test_invalid_property_raises_hubspot_client_error(self):
         contact = make_contact(None, properties={'is_polite': 'notavalidinput'})
-        connection = self._make_connection_for_contact_with_exception(contact, HubspotClientError("Property notavalidinput is invalid", "request-id"))
-
-        with assert_raises(HubspotClientError) as context:
-            with connection:
-                save_contact(contact, connection)
-        eq_(context.exception.message, "Property notavalidinput is invalid")
+        with self._make_connection_for_contact_with_exception(
+                contact,
+                HubspotClientError("Property notavalidinput is invalid", "request-id")) as connection:
+            with assert_raises(HubspotClientError) as context:
+                with connection:
+                    save_contact(contact, connection)
+            eq_(context.exception.message, "Property notavalidinput is invalid")
 
     @staticmethod
     def _make_connection_for_contact_with_exception(contact, exception, available_property=None):
@@ -52,9 +52,8 @@ class TestUpdateContact(object):
 
     def test_update_single_contact(self):
         contact = make_contact(1)
-        connection = self._make_connection_for_contact(contact)
-
-        update_contact(contact, connection)
+        with self._make_connection_for_contact(contact) as connection:
+            update_contact(contact, connection)
 
     @staticmethod
     def _make_connection_for_contact(contact, available_property=None):


### PR DESCRIPTION
MockPortalConnection only makes the assertions about API calls in it's **exit**() method
